### PR TITLE
add gorelease and deploy script in .travis.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ profile.cov
 /dashboard/assets/package-lock.json
 
 **/yarn-error.log
+/dist/*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,64 @@
+project_name: sipe
+env:
+- GO111MODULE=on
+before:
+  hooks:
+  - go env -w GOPROXY=https://goproxy.cn,direct
+  - go mod download
+builds:
+- id: sipe-darwin-amd64
+  ldflags: -s -w -X github.com/simplechain-org/go-simplechain.Version={{.Version}} -X github.com/simplechain-org/go-simplechain.BuildDate={{.Date}} -X github.com/simplechain-org/go-simplechain.CommitHash={{ .ShortCommit }}
+  binary: sipe
+  env:
+  - CGO_ENABLED=1
+  - CC=o64-clang
+  - CXX=o64-clang++
+  main: ./cmd/sipe/
+  goos:
+  - darwin
+  goarch:
+  - amd64
+- id: sipe-linux-amd64
+  ldflags: -s -w -X github.com/simplechain-org/go-simplechain.Version={{.Version}} -X github.com/simplechain-org/go-simplechain.BuildDate={{.Date}} -X github.com/simplechain-org/go-simplechain.CommitHash={{ .ShortCommit }}
+  binary: sipe
+  env:
+  - CGO_ENABLED=1
+  main: ./cmd/sipe/
+  goos:
+  - linux
+  goarch:
+  - amd64
+
+- id: sipe-windows-amd64
+  ldflags: -s -w -X github.com/simplechain-org/go-simplechain.Version={{.Version}} -X github.com/simplechain-org/go-simplechain.BuildDate={{.Date}} -X github.com/simplechain-org/go-simplechain.CommitHash={{ .ShortCommit }}
+  binary: sipe
+  env:
+  - CGO_ENABLED=1
+  - CC=x86_64-w64-mingw32-gcc
+  - CXX=x86_64-w64-mingw32-g++
+  main: ./cmd/sipe/
+  goos:
+  - windows
+  goarch:
+  - amd64
+archives:
+- format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  name_template: "{{.ProjectName}}-{{.Tag}}-{{.Os}}-{{.Arch}}"
+  wrap_in_directory: true
+  replacements:
+    macOS: darwin
+    Linux: linux
+    Windows: windows
+  files:
+  - README.md
+checksum:
+  name_template: 'checksums.txt'
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,6 @@ env:
 - GO111MODULE=on
 before:
   hooks:
-  - go env -w GOPROXY=https://goproxy.cn,direct
   - go mod download
 builds:
 - id: sipe-darwin-amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,15 @@ jobs:
         - unset -f cd # workaround for https://github.com/travis-ci/travis-ci/issues/8703
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
+deploy:
+- provider: script
+  script: docker run -e GITHUB_TOKEN=$GITHUB_TOKEN --rm --privileged -v $TRAVIS_BUILD_DIR:/go/src/github.com/simplechain-org/go-simplechain -v /var/run/docker.sock:/var/run/docker.sock -w /go/src/github.com/simplechain-org/go-simplechain mailchain/goreleaser-xcgo --rm-dist
+  skip_cleanup: true
+  on:
+      tags: true
+      repo: simplechain-org/go-simplechain
+      branch: master
+      condition: $DEPLOY = true
 
 #    # This builder does the Ubuntu PPA upload
 #    - stage: build


### PR DESCRIPTION
添加了goreleaser的功能，可以在项目的根目录下以下命令来生成mac,linux,windows三个平台下的可执行文件：
docker run --rm --privileged \
  -v $PWD:/go/src/github.com/simplechain-org/go-simplechain \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -w /go/src/github.com/simplechain-org/go-simplechain \
  mailchain/goreleaser-xcgo --snapshot --rm-dist
发布新版
需要发布新版本了，给发版的commit打一个tag，然后推送到仓库，这时travis将会执行相应的脚本将tar.gz或zip包自动部署到项目的release中